### PR TITLE
Place scripts into <head> rather than <body>.

### DIFF
--- a/lib/google_analytics_hooks.rb
+++ b/lib/google_analytics_hooks.rb
@@ -4,7 +4,7 @@ class GoogleAnalyticsHooks < Redmine::Hook::ViewListener
 
   # Adds the Google Analytics code to the layout if the current user meets
   # the conditions setup by the System Administrator
-  def view_layouts_base_body_bottom(context = { })
+  def view_layouts_base_html_head(context = { })
     log_anon = Setting.plugin_google_analytics_plugin['google_analytics_log_anonymous']
     log_auth = Setting.plugin_google_analytics_plugin['google_analytics_log_authenticated']
     log_admin = Setting.plugin_google_analytics_plugin['google_analytics_log_administrator']


### PR DESCRIPTION
Google Analytics scripts are recommended to be located in
the <head> section of a webpage.