### PR TITLE
Support redmine-5.1

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'redmine'
 
-require_dependency 'google_analytics_hooks'
+require File.expand_path('../lib/google_analytics_hooks', __FILE__)
 
 Redmine::Plugin.register :google_analytics_plugin do
   name 'Google Analytics plugin'

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,3 @@
-require 'redmine'
-
 require File.expand_path('../lib/google_analytics_hooks', __FILE__)
 
 Redmine::Plugin.register :google_analytics_plugin do


### PR DESCRIPTION
Currently master (2852489dd4d30bd91c65303c3d46bb3d16916f1f) on redmine-5.1.3 occur LoadError as following:

```console
yuya@yoshiyuki|16:08:00|0|12.7% bin/rails server
=> Booting Puma
=> Rails 6.1.7.8 application starting in development
=> Run `bin/rails server --help` for more startup options
Exiting
<internal:/home/yuya/.anyenv/envs/rbenv/versions/3.2.6/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require': cannot load such file -- google_analytics_hooks (LoadError)
        from <internal:/home/yuya/.anyenv/envs/rbenv/versions/3.2.6/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
        from /home/yuya/.anyenv/envs/rbenv/versions/3.2.6/lib/ruby/gems/3.2.0/gems/zeitwerk-2.7.1/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
        from /home/yuya/.anyenv/envs/rbenv/versions/3.2.6/lib/ruby/gems/3.2.0/gems/activesupport-6.1.7.8/lib/active_support/dependencies/zeitwerk_integration.rb:51:in `require_dependency'
        from /home/yuya/src/github.com/redmine/redmine/plugins/google_analytics_plugin/init.rb:3:in `<top (required)>'
        from /home/yuya/src/github.com/redmine/redmine/lib/redmine/plugin_loader.rb:31:in `load'
```

This. pull-request fixes it.
